### PR TITLE
Convert Capability from V20

### DIFF
--- a/src/AasxCsharpLibrary/Extensions/ExtendISubmodelElement.cs
+++ b/src/AasxCsharpLibrary/Extensions/ExtendISubmodelElement.cs
@@ -491,6 +491,10 @@ namespace Extensions
 
                     outputSubmodelElement = new Operation(inputVariables: newInputVariables, outputVariables: newOutputVariables, inoutputVariables: newInOutVariables);
                 }
+                else if (sourceSubmodelElement is AdminShellV20.Capability)
+                {
+                    outputSubmodelElement = new Capability();
+                }
 
                 outputSubmodelElement.BasicConversionFromV20(sourceSubmodelElement);
             }


### PR DESCRIPTION
When loading a package with Capability elements from Version 2.0, an error occurs because Capabilities are currently not converted. This commit adds the necessary condition to initialize the target element for Capabilities.