### PR TITLE
AasxCsharpLibrary: Add conversion for Capability elements from V2

### DIFF
--- a/src/AasxCsharpLibrary/Extensions/ExtendISubmodelElement.cs
+++ b/src/AasxCsharpLibrary/Extensions/ExtendISubmodelElement.cs
@@ -491,6 +491,10 @@ namespace Extensions
 
                     outputSubmodelElement = new Operation(inputVariables: newInputVariables, outputVariables: newOutputVariables, inoutputVariables: newInOutVariables);
                 }
+                else if (sourceSubmodelElement is AdminShellV20.Capability)
+                {
+                    outputSubmodelElement = new Capability();
+                }
 
                 outputSubmodelElement.BasicConversionFromV20(sourceSubmodelElement);
             }


### PR DESCRIPTION
This addresses an issue where packages with Capability elements could not be loaded in V3.