### PR TITLE
Fix for GitHub issue 199

### DIFF
--- a/src/AasxPackageLogic/ThingDescription/TDJsonImport.cs
+++ b/src/AasxPackageLogic/ThingDescription/TDJsonImport.cs
@@ -932,7 +932,10 @@ namespace AasxPackageExplorer
         // AAS Semantic ID
         public static Aas.Reference createSemanticID(string tdType)
         {
-            Aas.Reference tdSemanticId = new(Aas.ReferenceTypes.ExternalReference, new List<Aas.IKey>() { new Aas.Key((Aas.KeyTypes)Aas.Stringification.KeyTypesFromString(tdType), TDSemanticId.getSemanticID(tdType)) });
+            var key = Aas.Stringification.KeyTypesFromString(tdType);
+            Aas.Reference tdSemanticId = new(Aas.ReferenceTypes.ExternalReference, new List<Aas.IKey>() {
+                new Aas.Key(key == null ? Aas.KeyTypes.GlobalReference : (Aas.KeyTypes)key,
+                    TDSemanticId.getSemanticID(tdType))});
 
             return tdSemanticId;
         }


### PR DESCRIPTION
Fixes the issue. 

Uses the KeyType "GlobalReference" in case of creating semantic id,
while importing JSON LD.