### PR TITLE
Maintain Docker as default tool for building AsciiDoc

### DIFF
--- a/src/AasxPluginExportTable/AasxPluginExportTable.options.json
+++ b/src/AasxPluginExportTable/AasxPluginExportTable.options.json
@@ -1,11 +1,11 @@
 ﻿{
     "TemplateIdConceptDescription": "www.example.com/ids/cd/DDDD_DDDD_DDDD_DDDD",
     // the following options, if Docker (Desktop) is installed:
-    // "SmtExportHtmlCmd": "docker",
-    // "SmtExportPdfCmd": "docker",
+    "SmtExportHtmlCmd": "docker",
+    "SmtExportPdfCmd": "docker",
     // the following options, if Podman (open source replacement for Docker) is installed:
-    "SmtExportHtmlCmd": "podman",
-    "SmtExportPdfCmd": "podman",
+    // "SmtExportHtmlCmd": "podman",
+    // "SmtExportPdfCmd": "podman",
     "SmtExportHtmlArgs": "run -it -v %WD%:/documents/ asciidoctor/docker-asciidoctor asciidoctor -r asciidoctor-diagram -a stylesheet=asciidoc-style-idta.css %ADOC%",
     "SmtExportPdfArgs": "run -it -v %WD%:/documents/ asciidoctor/docker-asciidoctor asciidoctor-pdf -r asciidoctor-diagram -r ./extended.rb -a toc=macro -a pdf-theme=my-theme.yml -a env-pdf %ADOC%",
     // this is required to ignore a non-critical error message from podman, preventing the export to stop.


### PR DESCRIPTION
In recent commits, podman was introduced as an alternative 
for running the necessary containers for building AsciiDoc.

Padman is open source, works on top of vanilla Microsoft WSL2, 
does not require administrator privileges, does also not require a 
constant running software (daemon) in the background of 
Windows, allows side-by-side installation with Docker and 
provides basically the same syntax, just another cli invocation.

The behavior could be easily switched by editing 
AasxPluginExportTable.options.json.

However, to meet current users expectations, the default 
is switched back to 'docker' command, for the time being.
