### PR TITLE
Fix browser and bump nugets

### DIFF
--- a/src/AasCore.Aas3_0/AasCore.Aas3_0.csproj
+++ b/src/AasCore.Aas3_0/AasCore.Aas3_0.csproj
@@ -20,6 +20,6 @@
     <PackageTags>aas;asset administration shell;iiot;industry internet of things;industrie 4.0;i4.0</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
 </Project>

--- a/src/AasxAmlImExport/AasxAmlImExport.csproj
+++ b/src/AasxAmlImExport/AasxAmlImExport.csproj
@@ -15,11 +15,11 @@
     <EmbeddedResource Include="Resources\AssetAdministrationShellLib.aml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Aml.Engine" Version="2.0.9" />
-    <PackageReference Include="dotNetRDF" Version="2.7.5" />
-    <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
-    <PackageReference Include="System.IO.Packaging" Version="7.0.0" />
+    <PackageReference Include="Aml.Engine" Version="4.4.4" />
+    <PackageReference Include="dotNetRDF" Version="3.4.1" />
+    <PackageReference Include="System.Drawing.Common" Version="9.0.10" />
+    <PackageReference Include="System.IO.Packaging" Version="9.0.10" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Text.Json" Version="9.0.2" />
+    <PackageReference Include="System.Text.Json" Version="9.0.10" />
   </ItemGroup>
 </Project>

--- a/src/AasxBammRdfImExport/AasxBammRdfImExport.csproj
+++ b/src/AasxBammRdfImExport/AasxBammRdfImExport.csproj
@@ -9,11 +9,11 @@
 		<ProjectReference Include="..\AasxIntegrationBase\AasxIntegrationBase.csproj" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="dotNetRDF" Version="2.7.5" />
-		<PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-		<PackageReference Include="System.Drawing.Common" Version="7.0.0" />
-		<PackageReference Include="System.IO.Packaging" Version="7.0.0" />
+		<PackageReference Include="dotNetRDF" Version="3.4.1" />
+		<PackageReference Include="JetBrains.Annotations" Version="2025.2.2" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+		<PackageReference Include="System.Drawing.Common" Version="9.0.10" />
+		<PackageReference Include="System.IO.Packaging" Version="9.0.10" />
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 	</ItemGroup>
 	<ItemGroup>

--- a/src/AasxCore.Samm2_2_0/AasxCore.Samm2_2_0.csproj
+++ b/src/AasxCore.Samm2_2_0/AasxCore.Samm2_2_0.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.IO.Packaging" Version="7.0.0" />
+    <PackageReference Include="System.IO.Packaging" Version="9.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AasxCsharpLibrary/AasxCsharpLibrary.csproj
+++ b/src/AasxCsharpLibrary/AasxCsharpLibrary.csproj
@@ -32,13 +32,13 @@
     <EmbeddedResource Include="Resources\schemaV201\aas.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.0.2" />
-    <PackageReference Include="Namotion.Reflection" Version="2.1.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="NJsonSchema" Version="10.8.0" />
-    <PackageReference Include="System.ComponentModel.Composition" Version="6.0.0" />
-    <PackageReference Include="System.IO.Packaging" Version="7.0.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2025.2.2" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.14.0" />
+    <PackageReference Include="Namotion.Reflection" Version="3.4.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="NJsonSchema" Version="11.5.2" />
+    <PackageReference Include="System.ComponentModel.Composition" Version="9.0.10" />
+    <PackageReference Include="System.IO.Packaging" Version="9.0.10" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AasCore.Aas3_0\AasCore.Aas3_0.csproj" />

--- a/src/AasxDictionaryImport/AasxDictionaryImport.csproj
+++ b/src/AasxDictionaryImport/AasxDictionaryImport.csproj
@@ -15,11 +15,11 @@
     <ProjectReference Include="..\AasxWpfControlLibrary\AasxWpfControlLibrary.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ExcelDataReader" Version="3.6.0" />
+    <PackageReference Include="ExcelDataReader" Version="3.8.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
     <PackageReference Include="RestSharp" Version="112.1.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
-    <PackageReference Include="System.Formats.Asn1" Version="9.0.2" />
-    <PackageReference Include="System.Text.Json" Version="9.0.2" />
+    <PackageReference Include="System.Formats.Asn1" Version="9.0.10" />
+    <PackageReference Include="System.Text.Json" Version="9.0.10" />
   </ItemGroup>
 </Project>

--- a/src/AasxFileServerRestLibrary/AasxFileServerRestLibrary.csproj
+++ b/src/AasxFileServerRestLibrary/AasxFileServerRestLibrary.csproj
@@ -10,11 +10,11 @@
 		<Using Include="AasCore.Aas3_0" />
 	</ItemGroup>
   <ItemGroup>
-    <PackageReference Include="JsonSubTypes" Version="1.9.0" />
+    <PackageReference Include="JsonSubTypes" Version="2.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="RestSharp" Version="112.1.0" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="9.0.2" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="9.0.10" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AasCore.Aas3_0\AasCore.Aas3_0.csproj" />

--- a/src/AasxFormatCst/AasxFormatCst.csproj
+++ b/src/AasxFormatCst/AasxFormatCst.csproj
@@ -14,8 +14,8 @@
     <ProjectReference Include="..\AasxIntegrationBase\AasxIntegrationBase.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.IO.Packaging" Version="7.0.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2025.2.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="System.IO.Packaging" Version="9.0.10" />
   </ItemGroup>
 </Project>

--- a/src/AasxIntegrationBase/AasxIntegrationBase.csproj
+++ b/src/AasxIntegrationBase/AasxIntegrationBase.csproj
@@ -14,7 +14,7 @@
     <ProjectReference Include="..\AnyUi\AnyUi.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.IO.Packaging" Version="7.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="System.IO.Packaging" Version="9.0.10" />
   </ItemGroup>
 </Project>

--- a/src/AasxIntegrationBaseGdi/AasxIntegrationBaseGdi.csproj
+++ b/src/AasxIntegrationBaseGdi/AasxIntegrationBaseGdi.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="13.10.0" />
-    <PackageReference Include="Magick.NET.Core" Version="13.10.0" />
-    <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
-    <PackageReference Include="System.IO.Packaging" Version="7.0.0" />
+    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="14.9.1" />
+    <PackageReference Include="Magick.NET.Core" Version="14.9.1" />
+    <PackageReference Include="System.Drawing.Common" Version="9.0.10" />
+    <PackageReference Include="System.IO.Packaging" Version="9.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AasxIntegrationBaseWpf/AasxIntegrationBaseWpf.csproj
+++ b/src/AasxIntegrationBaseWpf/AasxIntegrationBaseWpf.csproj
@@ -25,10 +25,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ExhaustiveMatching.Analyzer" Version="0.5.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Microsoft.Windows.Compatibility" Version="7.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="Microsoft.Windows.Compatibility" Version="9.0.10" />
     <PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
-    <PackageReference Include="System.Formats.Asn1" Version="9.0.2" />
+    <PackageReference Include="System.Formats.Asn1" Version="9.0.10" />
   </ItemGroup>
   <ItemGroup>
     <Page Remove="OriginalResources\FormSmaller.xaml" />

--- a/src/AasxIntegrationEmptySample/AasxIntegrationEmptySample.csproj
+++ b/src/AasxIntegrationEmptySample/AasxIntegrationEmptySample.csproj
@@ -9,7 +9,7 @@
     <ProjectReference Include="..\AasxIntegrationBase\AasxIntegrationBase.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
-    <PackageReference Include="System.IO.Packaging" Version="7.0.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2025.2.2" />
+    <PackageReference Include="System.IO.Packaging" Version="9.0.10" />
   </ItemGroup>
 </Project>

--- a/src/AasxMqtt/AasxMqtt.csproj
+++ b/src/AasxMqtt/AasxMqtt.csproj
@@ -11,8 +11,8 @@
     <ProjectReference Include="..\AasxIntegrationBase\AasxIntegrationBase.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2025.2.2" />
     <PackageReference Include="MQTTnet" Version="3.0.5" />
-    <PackageReference Include="System.IO.Packaging" Version="7.0.0" />
+    <PackageReference Include="System.IO.Packaging" Version="9.0.10" />
   </ItemGroup>
 </Project>

--- a/src/AasxMqttClient/AasxMqttClient.csproj
+++ b/src/AasxMqttClient/AasxMqttClient.csproj
@@ -14,9 +14,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Grapevine" Version="4.2.2" />
-    <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
-    <PackageReference Include="MQTTnet" Version="4.1.1.318" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.IO.Packaging" Version="7.0.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2025.2.2" />
+    <PackageReference Include="MQTTnet" Version="3.1.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="System.IO.Packaging" Version="9.0.10" />
   </ItemGroup>
 </Project>

--- a/src/AasxMqttClient/MqttClient.cs
+++ b/src/AasxMqttClient/MqttClient.cs
@@ -22,6 +22,7 @@ using AnyUi;
 using Extensions;
 using MQTTnet;
 using MQTTnet.Client;
+using MQTTnet.Client.Options;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;

--- a/src/AasxOpcUa2Client/AasxOpcUa2Client.csproj
+++ b/src/AasxOpcUa2Client/AasxOpcUa2Client.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.IO.Packaging" Version="7.0.0" />
+    <PackageReference Include="System.IO.Packaging" Version="9.0.10" />
     <PackageReference Include="Workstation.UaClient" Version="3.2.3" />
   </ItemGroup>
 

--- a/src/AasxOpenidClient/AasxOpenidClient.csproj
+++ b/src/AasxOpenidClient/AasxOpenidClient.csproj
@@ -23,11 +23,11 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="IdentityModel" Version="6.0.0" />
-    <PackageReference Include="jose-jwt" Version="4.0.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.1.2" />
-    <PackageReference Include="System.IO.Packaging" Version="7.0.0" />
-    <PackageReference Include="System.Text.Json" Version="9.0.2" />
+    <PackageReference Include="jose-jwt" Version="5.2.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.14.0" />
+    <PackageReference Include="System.IO.Packaging" Version="9.0.10" />
+    <PackageReference Include="System.Text.Json" Version="9.0.10" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AasxIntegrationBase\AasxIntegrationBase.csproj" />

--- a/src/AasxPackageExplorer/AasxPackageExplorer.csproj
+++ b/src/AasxPackageExplorer/AasxPackageExplorer.csproj
@@ -149,21 +149,21 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AvalonEdit" Version="6.2.0.78" />
+    <PackageReference Include="AvalonEdit" Version="6.3.1.120" />
     <PackageReference Include="ExhaustiveMatching.Analyzer" Version="0.5.0" />
-    <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
-    <PackageReference Include="jose-jwt" Version="4.0.1" />
-    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="13.10.0" />
-    <PackageReference Include="Magick.NET.Core" Version="13.10.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2025.2.2" />
+    <PackageReference Include="jose-jwt" Version="5.2.0" />
+    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="14.9.1" />
+    <PackageReference Include="Magick.NET.Core" Version="14.9.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="RestSharp" Version="112.1.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
-    <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
+    <PackageReference Include="System.Drawing.Common" Version="9.0.10" />
     <PackageReference Include="SSharp.Net" Version="1.0.1" />
-    <PackageReference Include="System.Formats.Asn1" Version="9.0.2" />
+    <PackageReference Include="System.Formats.Asn1" Version="9.0.10" />
     <PackageReference Include="System.Private.Uri" Version="4.3.2" />
-    <PackageReference Include="System.Text.Json" Version="9.0.2" />
+    <PackageReference Include="System.Text.Json" Version="9.0.10" />
     <PackageReference Include="Workstation.UaClient" Version="3.2.3" />
   </ItemGroup>
   <ItemGroup>

--- a/src/AasxPackageExplorer/MainWindow.xaml.cs
+++ b/src/AasxPackageExplorer/MainWindow.xaml.cs
@@ -22,7 +22,6 @@ using Extensions;
 using J2N;
 using Microsoft.Win32;
 using Newtonsoft.Json;
-using NPOI.POIFS.Properties;
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/AasxPackageExplorer/options-debug.MIHO.json
+++ b/src/AasxPackageExplorer/options-debug.MIHO.json
@@ -19,7 +19,10 @@
         "C:\\HOMI\\Develop\\Aasx\\repo\\phoenix-api-key.json",
         "C:\\HOMI\\Develop\\Aasx\\repo\\local-basyx.json",
         "C:\\HOMI\\Develop\\Aasx\\repo\\reg-of-reg-voyager.json",
-        "C:\\HOMI\\Develop\\Aasx\\repo\\phoenix-big.json"
+        "C:\\HOMI\\Develop\\Aasx\\repo\\phoenix-big.json",
+        "C:\\HOMI\\Develop\\Aasx\\repo\\Festo-basyx.json",
+        "C:\\HOMI\\Develop\\Aasx\\repo\\Festo-apigee.json",
+        "C:\\HOMI\\Develop\\Aasx\\repo\\reg-of-reg-plugfest3.json"
     ]
     /* When connecting to given URIs, auto-authenticate by matching with known endpoints. */,
     "AutoAuthenticateUris": true

--- a/src/AasxPackageExplorer/options-debug.MIHO.json
+++ b/src/AasxPackageExplorer/options-debug.MIHO.json
@@ -7,7 +7,7 @@
     // "AasxToLoad": "http://localhost:8081/shells/aHR0cHM6Ly9hZG1pbi1zaGVsbC1pby9pZHRhL2Fhcy9Qcm9kdWN0Q2hhbmdlTm90aWZpY2F0aW9ucy8xLzA"
     // "AasxToLoad": "http://localhost:8081/shells/aHR1cHM6Ly9hZG1pbi1zaGVsbC1pby9pZHRhL2Fhcy9Qcm9kdWN0Q2hhbmdlTm90aWZpY2F0aW9ucy8xLzA"
     // "AasxToLoad": "C:\\Users\\Micha\\Desktop\\test-smt-on-basyx\\IDTA_02036-1-0_SMT_ProductChangeNotification_Draft_v35_manual_fixes.aasx"
-    "AasxToLoad": "C:\\HOMI\\Develop\\Aasx\\SMT\\IDTA 02036-1-0_Submodel_ProductChangeNotification\\IDTA_02036-1-0_SMT_ProductChangeNotification_Draft_v40_add_podman.aasx"
+    "AasxToLoad": "C:\\HOMI\\Develop\\Aasx\\SMT\\IDTA 02036-1-0_Submodel_ProductChangeNotification\\IDTA_02036-1-0_SMT_ProductChangeNotification_Draft_v41_check_IRDIs.aasx"
     /* This file shall be loaded as aux package at start of application | Arg: <path> */,
     "AuxToLoad": null
     /* List of pathes to a JSON, defining a set of AasxPackage-Files, which serve as repository. | Arg: <path> */,

--- a/src/AasxPackageLogic/AasxPackageLogic.csproj
+++ b/src/AasxPackageLogic/AasxPackageLogic.csproj
@@ -33,18 +33,18 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="dotNetRdf" Version="3.1.1" />
+    <PackageReference Include="dotNetRdf" Version="3.4.1" />
     <PackageReference Include="IdentityModel" Version="6.0.0" />
-    <PackageReference Include="jose-jwt" Version="4.0.1" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.74.0" />
+    <PackageReference Include="jose-jwt" Version="5.2.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.78.0" />
     <PackageReference Include="Microsoft.VisualBasic" Version="10.3.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="RestSharp" Version="112.1.0" />
     <PackageReference Include="SSharp.Net" Version="1.0.1" />
     <PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
-    <PackageReference Include="System.Formats.Asn1" Version="9.0.2" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.1.2" />
-    <PackageReference Include="System.Text.Json" Version="9.0.2" />
+    <PackageReference Include="System.Formats.Asn1" Version="9.0.10" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.14.0" />
+    <PackageReference Include="System.Text.Json" Version="9.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AasxPackageLogic/DispEditHelperBasics.cs
+++ b/src/AasxPackageLogic/DispEditHelperBasics.cs
@@ -2651,7 +2651,8 @@ namespace AasxPackageLogic
                             if (list.Count < 1)
                                 setOutputList?.Invoke(null);
 
-                            await postActionHookAsync?.Invoke(theMenu?.ElementAt(buttonNdx)?.Name, ticket);
+                            if (postActionHookAsync != null)
+                                await postActionHookAsync.Invoke(theMenu?.ElementAt(buttonNdx)?.Name, ticket);
 
                             this.AddDiaryEntry(entityRf,
                                 new DiaryEntryStructChange(StructuralChangeReason.Delete),

--- a/src/AasxPackageLogic/PackageCentral/KnownEndpointDescription.cs
+++ b/src/AasxPackageLogic/PackageCentral/KnownEndpointDescription.cs
@@ -109,6 +109,11 @@ namespace AasxPackageLogic.PackageCentral
         /// Note: Default is rather short because of secure by design
         /// </summary>
         public int RenewPeriodMins = 5;
+
+        /// <summary>
+        /// Scope to be send with the token generation access to be embedded into
+        /// </summary>
+        public string Scope = "";
     }
 
     public class KnownEndpointDescription

--- a/src/AasxPackageLogic/PackageCentral/PackageContainerHttpRepoSubset.cs
+++ b/src/AasxPackageLogic/PackageCentral/PackageContainerHttpRepoSubset.cs
@@ -375,6 +375,11 @@ namespace AasxPackageLogic.PackageCentral
                 {
                     return new Uri(location.Substring(0, p) + "/");
                 }
+                else
+                {
+                    // no seconds slash -> whole is a base url
+                    return new Uri(location + "/");
+                }
             }
 
             // go to error
@@ -826,49 +831,101 @@ namespace AasxPackageLogic.PackageCentral
 
             foreach (var ep in aasDescriptor.endpoints)
             {
+                // gather informaation
+                AasIdentifiableSideInfo aasSi = null;
+                List<AasIdentifiableSideInfo> smSiReg = null;
+
                 // strictly check IFC
                 var aasIfc = "" + ep["interface"];
-                if (aasIfc != "AAS-1.0")
-                    continue;
-
-                // direct access HREF
-                var aasSi = new AasIdentifiableSideInfo()
+                if (aasIfc == "AAS-1.0")
                 {
-                    IsStub = false,
-                    StubLevel = AasIdentifiableSideInfoLevel.IdWithEndpoint,
-                    Id = "" + aasDescriptor.id,
-                    IdShort = "" + aasDescriptor.idShort,
-                    QueriedEndpoint = new Uri("" + ep.protocolInformation.href),
-                    DesignatedEndpoint = new Uri("" + ep.protocolInformation.href)
-                };
 
-                // but in order to operate as registry, a list of Submodel endpoints
-                // is required as well
-                var smRegged = new List<AasIdentifiableSideInfo>();
-                if (AdminShellUtil.DynamicHasProperty(aasDescriptor, "submodelDescriptors"))
-                    foreach (var smdesc in aasDescriptor.submodelDescriptors)
+                    // direct access HREF
+                    aasSi = new AasIdentifiableSideInfo()
                     {
-                        foreach (var smep in smdesc.endpoints)
-                        {
-                            // strictly check IFC
-                            var smIfc = "" + smep["interface"];
-                            if (smIfc != "SUBMODEL-1.0")
-                                continue;
+                        IsStub = false,
+                        StubLevel = AasIdentifiableSideInfoLevel.IdWithEndpoint,
+                        Id = "" + aasDescriptor.id,
+                        IdShort = "" + aasDescriptor.idShort,
+                        QueriedEndpoint = new Uri("" + ep.protocolInformation.href),
+                        DesignatedEndpoint = new Uri("" + ep.protocolInformation.href)
+                    };
 
-                            // ok
-                            string href = smep.protocolInformation.href;
-                            if (href.HasContent() == true)
-                                smRegged.Add(new AasIdentifiableSideInfo()
-                                {
-                                    IsStub = true,
-                                    StubLevel = AasIdentifiableSideInfoLevel.IdWithEndpoint,
-                                    Id = smdesc.id,
-                                    IdShort = smdesc.idShort,
-                                    QueriedEndpoint = new Uri(href),
-                                    DesignatedEndpoint = new Uri(href)
-                                });
+                    // but in order to operate as registry, a list of Submodel endpoints
+                    // is required as well
+                    smSiReg = new List<AasIdentifiableSideInfo>();
+                    if (AdminShellUtil.DynamicHasProperty(aasDescriptor, "submodelDescriptors"))
+                        foreach (var smdesc in aasDescriptor.submodelDescriptors)
+                        {
+                            foreach (var smep in smdesc.endpoints)
+                            {
+                                // strictly check IFC
+                                var smIfc = "" + smep["interface"];
+                                if (smIfc != "SUBMODEL-1.0")
+                                    continue;
+
+                                // ok
+                                string href = smep.protocolInformation.href;
+                                if (href.HasContent() == true)
+                                    smSiReg.Add(new AasIdentifiableSideInfo()
+                                    {
+                                        IsStub = true,
+                                        StubLevel = AasIdentifiableSideInfoLevel.IdWithEndpoint,
+                                        Id = smdesc.id,
+                                        IdShort = smdesc.idShort,
+                                        QueriedEndpoint = new Uri(href),
+                                        DesignatedEndpoint = new Uri(href)
+                                    });
+                            }
                         }
-                    }
+                }
+                else if (aasIfc == "AAS-3.0")
+                {
+                    // Remark: Suspicously, this will be an exacht copy 1.0 == 3.0   :-(
+                    // direct access HREF
+                    aasSi = new AasIdentifiableSideInfo()
+                    {
+                        IsStub = false,
+                        StubLevel = AasIdentifiableSideInfoLevel.IdWithEndpoint,
+                        Id = "" + aasDescriptor.id,
+                        IdShort = "" + aasDescriptor.idShort,
+                        QueriedEndpoint = new Uri("" + ep.protocolInformation.href),
+                        DesignatedEndpoint = new Uri("" + ep.protocolInformation.href)
+                    };
+
+                    // but in order to operate as registry, a list of Submodel endpoints
+                    // is required as well
+                    smSiReg = new List<AasIdentifiableSideInfo>();
+                    if (AdminShellUtil.DynamicHasProperty(aasDescriptor, "submodelDescriptors"))
+                        foreach (var smdesc in aasDescriptor.submodelDescriptors)
+                        {
+                            foreach (var smep in smdesc.endpoints)
+                            {
+                                // strictly check IFC
+                                var smIfc = "" + smep["interface"];
+                                if (smIfc != "SUBMODEL-3.0")
+                                    continue;
+
+                                // ok
+                                string href = smep.protocolInformation.href;
+                                if (href.HasContent() == true)
+                                    smSiReg.Add(new AasIdentifiableSideInfo()
+                                    {
+                                        IsStub = true,
+                                        StubLevel = AasIdentifiableSideInfoLevel.IdWithEndpoint,
+                                        Id = smdesc.id,
+                                        IdShort = smdesc.idShort,
+                                        QueriedEndpoint = new Uri(href),
+                                        DesignatedEndpoint = new Uri(href)
+                                    });
+                            }
+                        }
+                }
+                else
+                {
+                    // no chance
+                    continue;
+                }
 
                 // ok
                 var aas = await PackageHttpDownloadUtil.DownloadIdentifiableToOK<Aas.IAssetAdministrationShell>(
@@ -892,7 +949,7 @@ namespace AasxPackageLogic.PackageCentral
 
                 // make sure the list of Submodel endpoints is the same (in numbers)
                 // as the AAS expects
-                if (smRegged.Count != uniqSms.Count())
+                if (smSiReg.Count != uniqSms.Count())
                 {
                     Log.Singleton.Info(StoredPrint.Color.Blue,
                         "For downloading AAS at {0}, the number of Submodels " +
@@ -906,7 +963,7 @@ namespace AasxPackageLogic.PackageCentral
                 // makes most sense to "recrate" the AAS.Submodels with the side infos
                 // from the registry
                 aas.Submodels = null;
-                foreach (var smrr in smRegged)
+                foreach (var smrr in smSiReg)
                     aas.AddSubmodelReference(new Aas.Reference(
                         ReferenceTypes.ModelReference,
                         (new Aas.IKey[] { new Aas.Key(KeyTypes.Submodel, smrr.Id) }).ToList()));
@@ -923,7 +980,7 @@ namespace AasxPackageLogic.PackageCentral
                     // be prepared to download them
                     var numRes = await PackageHttpDownloadUtil.DownloadListOfIdentifiables<Aas.ISubmodel, AasIdentifiableSideInfo>(
                         null,
-                        smRegged,
+                        smSiReg,
                         lambdaGetLocation: (si) => si.QueriedEndpoint,
                         runtimeOptions: runtimeOptions,
                         allowFakeResponses: allowFakeResponses,
@@ -951,7 +1008,7 @@ namespace AasxPackageLogic.PackageCentral
                 }
                 else
                 {
-                    foreach (var si in smRegged)
+                    foreach (var si in smSiReg)
                     {
                         // valid Id is required
                         if (si?.Id?.HasContent() != true)
@@ -1025,10 +1082,18 @@ namespace AasxPackageLogic.PackageCentral
 
             // translate to a list of AAS-Ids ..
             var uriGetListOfAids = BuildUriForRegistryAasByAssetId(baseUris.GetBaseUriForAasReg(), assetId);
-            if (compatOldAasxServer)
-                uriGetListOfAids = BuildUriForRegistryAasByAssetLinkDeprecated(baseUris.GetBaseUriForAasReg(), assetId);
             var listOfAids = await PackageHttpDownloadUtil.DownloadEntityToDynamicObject(
                 uriGetListOfAids, runtimeOptions, allowFakeResponses);
+
+            if (compatOldAasxServer
+                && (listOfAids == null || !(listOfAids is JArray) || (listOfAids as JArray).Count < 1))
+            {
+                // repeat with deprecated call
+                uriGetListOfAids = BuildUriForRegistryAasByAssetLinkDeprecated(baseUris.GetBaseUriForAasReg(), assetId);
+
+                listOfAids = await PackageHttpDownloadUtil.DownloadEntityToDynamicObject(
+                    uriGetListOfAids, runtimeOptions, allowFakeResponses);
+            }
 
             if (listOfAids == null || !(listOfAids is JArray) || (listOfAids as JArray).Count < 1)
             {

--- a/src/AasxPackageLogic/PackageCentral/SecurityAccessHandlerLogicBase.cs
+++ b/src/AasxPackageLogic/PackageCentral/SecurityAccessHandlerLogicBase.cs
@@ -664,12 +664,16 @@ namespace AasxPackageExplorer
                 var secretRequest = new HttpRequestMessage(System.Net.Http.HttpMethod.Post, authConfigUrl);
                 secretRequest.Headers.Add("Accept", "application/json");
 
-                secretRequest.Content = new FormUrlEncodedContent(new[]
+                var reqContent = new List<KeyValuePair<string, string>>(new[]
                 {
                     new KeyValuePair<string, string>("grant_type", "client_credentials"),
                     new KeyValuePair<string, string>("client_id", id),
                     new KeyValuePair<string, string>("client_secret", secret)
                 });
+                if (endpoint.Endpoint.AccessInfo.Scope?.HasContent() == true)
+                    reqContent.Add(new KeyValuePair<string, string>("scope", endpoint.Endpoint.AccessInfo.Scope));
+
+                secretRequest.Content = new FormUrlEncodedContent(reqContent);
 
                 var secretResponse = await client.SendAsync(secretRequest);
                 var secretContentStr = await secretResponse.Content.ReadAsStringAsync();
@@ -990,6 +994,9 @@ namespace AasxPackageExplorer
                 })
             };
             request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/x-www-form-urlencoded");
+
+            // Festo?
+            request.Content.Headers.Add("scope", "offline_access basyx-api-access");
 
             // second request to auth-server: get token
             var response = await client.SendAsync(request);

--- a/src/AasxPluginAdvancedTextEditor/AasxPluginAdvancedTextEditor.csproj
+++ b/src/AasxPluginAdvancedTextEditor/AasxPluginAdvancedTextEditor.csproj
@@ -14,9 +14,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AvalonEdit" Version="6.2.0.78" />
+    <PackageReference Include="AvalonEdit" Version="6.3.1.120" />
     <PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
-    <PackageReference Include="System.Formats.Asn1" Version="9.0.2" />
+    <PackageReference Include="System.Formats.Asn1" Version="9.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AasxPluginAssetInterfaceDesc/AasxPluginAssetInterfaceDesc.csproj
+++ b/src/AasxPluginAssetInterfaceDesc/AasxPluginAssetInterfaceDesc.csproj
@@ -42,10 +42,10 @@
     <ProjectReference Include="..\AasxPredefinedConcepts\AasxPredefinedConcepts.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FluentModbus" Version="5.0.3" />
+    <PackageReference Include="FluentModbus" Version="5.3.2" />
     <PackageReference Include="MQTTnet" Version="4.1.1.318" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
-    <PackageReference Include="System.Formats.Asn1" Version="9.0.2" />
+    <PackageReference Include="System.Formats.Asn1" Version="9.0.10" />
   </ItemGroup>
 </Project>

--- a/src/AasxPluginBomStructure/AasxPluginBomStructure.csproj
+++ b/src/AasxPluginBomStructure/AasxPluginBomStructure.csproj
@@ -40,8 +40,8 @@
     <PackageReference Include="AutomaticGraphLayout" Version="1.1.12" />
     <PackageReference Include="AutomaticGraphLayout.Drawing" Version="1.1.12" />
     <PackageReference Include="AutomaticGraphLayout.WpfGraphControl" Version="1.1.12" />
-    <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.IO.Packaging" Version="7.0.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2025.2.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="System.IO.Packaging" Version="9.0.10" />
   </ItemGroup>
 </Project>

--- a/src/AasxPluginContactInformation/AasxPluginContactInformation.csproj
+++ b/src/AasxPluginContactInformation/AasxPluginContactInformation.csproj
@@ -30,8 +30,8 @@
     <EmbeddedResource Include="Resources\no-contact-preview.png" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.IO.Packaging" Version="7.0.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2025.2.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="System.IO.Packaging" Version="9.0.10" />
   </ItemGroup>
 </Project>

--- a/src/AasxPluginDigitalNameplate/AasxPluginDigitalNameplate.csproj
+++ b/src/AasxPluginDigitalNameplate/AasxPluginDigitalNameplate.csproj
@@ -55,9 +55,9 @@
     </Resource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="QRCoder" Version="1.4.3" />
-    <PackageReference Include="System.IO.Packaging" Version="7.0.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2025.2.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="QRCoder" Version="1.7.0" />
+    <PackageReference Include="System.IO.Packaging" Version="9.0.10" />
   </ItemGroup>
 </Project>

--- a/src/AasxPluginDigitalNameplate/NameplateAnyUiControl.cs
+++ b/src/AasxPluginDigitalNameplate/NameplateAnyUiControl.cs
@@ -30,6 +30,7 @@ using System.Windows.Forms;
 using QRCoder;
 using ImageMagick;
 using System.DirectoryServices.ActiveDirectory;
+using ImageMagick.Factories;
 
 
 namespace AasxPluginDigitalNameplate

--- a/src/AasxPluginDocumentShelf/AasxPluginDocumentShelf.csproj
+++ b/src/AasxPluginDocumentShelf/AasxPluginDocumentShelf.csproj
@@ -34,8 +34,8 @@
     </Resource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.IO.Packaging" Version="7.0.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2025.2.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="System.IO.Packaging" Version="9.0.10" />
   </ItemGroup>
 </Project>

--- a/src/AasxPluginExportTable/AasxPluginExportTable.csproj
+++ b/src/AasxPluginExportTable/AasxPluginExportTable.csproj
@@ -35,14 +35,13 @@
     </Resource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ClosedXML" Version="0.94.2" />
-    <PackageReference Include="DocumentFormat.OpenXml" Version="2.7.2" />
-    <PackageReference Include="ExcelNumberFormat" Version="1.0.3" />
-    <PackageReference Include="FastMember" Version="1.3.0" />
-    <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="ClosedXML" Version="0.105.0" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="3.3.0" />
+    <PackageReference Include="ExcelNumberFormat" Version="1.1.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2025.2.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
-    <PackageReference Include="System.Formats.Asn1" Version="9.0.2" />
+    <PackageReference Include="System.Formats.Asn1" Version="9.0.10" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
 </ItemGroup>

--- a/src/AasxPluginExportTable/AasxPluginExportTable.options.json
+++ b/src/AasxPluginExportTable/AasxPluginExportTable.options.json
@@ -1,11 +1,11 @@
 ﻿{
     "TemplateIdConceptDescription": "www.example.com/ids/cd/DDDD_DDDD_DDDD_DDDD",
     // the following options, if Docker (Desktop) is installed:
-    // "SmtExportHtmlCmd": "docker",
-    // "SmtExportPdfCmd": "docker",
+     "SmtExportHtmlCmd": "docker",
+     "SmtExportPdfCmd": "docker",
     // the following options, if Podman (open source replacement for Docker) is installed:
-    "SmtExportHtmlCmd": "podman",
-    "SmtExportPdfCmd": "podman",
+    //"SmtExportHtmlCmd": "podman",
+    //"SmtExportPdfCmd": "podman",
     "SmtExportHtmlArgs": "run -it -v %WD%:/documents/ asciidoctor/docker-asciidoctor asciidoctor -r asciidoctor-diagram -a stylesheet=asciidoc-style-idta.css %ADOC%",
     "SmtExportPdfArgs": "run -it -v %WD%:/documents/ asciidoctor/docker-asciidoctor asciidoctor-pdf -r asciidoctor-diagram -r ./extended.rb -a toc=macro -a pdf-theme=my-theme.yml -a env-pdf %ADOC%",
     // this is required to ignore a non-critical error message from podman, preventing the export to stop.

--- a/src/AasxPluginExportTable/Table/ImportTableExcelProvider.cs
+++ b/src/AasxPluginExportTable/Table/ImportTableExcelProvider.cs
@@ -34,7 +34,7 @@ namespace AasxPluginExportTable.Table
         {
             if (_worksheet == null)
                 return null;
-            return _worksheet.Cell(1 + row, 1 + col)?.Value?.ToString();
+            return _worksheet.Cell(1 + row, 1 + col)?.Value.ToString();
         }
 
         //

--- a/src/AasxPluginGenericForms/AasxPluginGenericForms.csproj
+++ b/src/AasxPluginGenericForms/AasxPluginGenericForms.csproj
@@ -47,8 +47,8 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.IO.Packaging" Version="7.0.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2025.2.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="System.IO.Packaging" Version="9.0.10" />
   </ItemGroup>
 </Project>

--- a/src/AasxPluginImageMap/AasxPluginImageMap.csproj
+++ b/src/AasxPluginImageMap/AasxPluginImageMap.csproj
@@ -16,9 +16,9 @@
     <Resource Include="LICENSE.TXT" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.IO.Packaging" Version="7.0.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2025.2.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="System.IO.Packaging" Version="9.0.10" />
   </ItemGroup>
   <ItemGroup>
     <None Update="AasxPluginImageMap.plugin">

--- a/src/AasxPluginKnownSubmodels/AasxPluginKnownSubmodels.csproj
+++ b/src/AasxPluginKnownSubmodels/AasxPluginKnownSubmodels.csproj
@@ -8,9 +8,9 @@
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.IO.Packaging" Version="7.0.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2025.2.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="System.IO.Packaging" Version="9.0.10" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AasxIntegrationBaseGdi\AasxIntegrationBaseGdi.csproj" />

--- a/src/AasxPluginMtpViewer/AasxPluginMtpViewer.csproj
+++ b/src/AasxPluginMtpViewer/AasxPluginMtpViewer.csproj
@@ -31,9 +31,9 @@
     <ProjectReference Include="..\WpfMtpControl\WpfMtpControl.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
-    <PackageReference Include="System.Formats.Asn1" Version="9.0.2" />
-    <PackageReference Include="System.Text.Json" Version="9.0.2" />
+    <PackageReference Include="System.Formats.Asn1" Version="9.0.10" />
+    <PackageReference Include="System.Text.Json" Version="9.0.10" />
   </ItemGroup>
 </Project>

--- a/src/AasxPluginPlotting/AasxPluginPlotting.csproj
+++ b/src/AasxPluginPlotting/AasxPluginPlotting.csproj
@@ -20,11 +20,11 @@
     <Resource Include="LICENSE.TXT" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="ScottPlot" Version="4.1.68" />
-    <PackageReference Include="ScottPlot.WPF" Version="4.1.68" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="ScottPlot" Version="4.1.74" />
+    <PackageReference Include="ScottPlot.WPF" Version="4.1.74" />
     <PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
-    <PackageReference Include="System.Formats.Asn1" Version="9.0.2" />
+    <PackageReference Include="System.Formats.Asn1" Version="9.0.10" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="WpfPlotViewControlCumulative.xaml.cs">

--- a/src/AasxPluginProductChangeNotifications/AasxPluginProductChangeNotifications.csproj
+++ b/src/AasxPluginProductChangeNotifications/AasxPluginProductChangeNotifications.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
-    <PackageReference Include="System.Formats.Asn1" Version="9.0.2" />
+    <PackageReference Include="System.Formats.Asn1" Version="9.0.10" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AasxIntegrationBaseGdi\AasxIntegrationBaseGdi.csproj" />

--- a/src/AasxPluginSmdExporter/AasxPluginSmdExporter.csproj
+++ b/src/AasxPluginSmdExporter/AasxPluginSmdExporter.csproj
@@ -31,16 +31,16 @@
         </EmbeddedResource>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="CsvHelper" Version="29.0.0" />
-        <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
+        <PackageReference Include="CsvHelper" Version="33.1.0" />
+        <PackageReference Include="JetBrains.Annotations" Version="2025.2.2" />
         <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
-        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.10" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="RestSharp" Version="112.1.0" />
         <PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
-        <PackageReference Include="System.Formats.Asn1" Version="9.0.2" />
-        <PackageReference Include="System.IO.Packaging" Version="7.0.0" />
-        <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
-        <PackageReference Include="System.Text.Json" Version="9.0.2" />
+        <PackageReference Include="System.Formats.Asn1" Version="9.0.10" />
+        <PackageReference Include="System.IO.Packaging" Version="9.0.10" />
+        <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
+        <PackageReference Include="System.Text.Json" Version="9.0.10" />
     </ItemGroup>
 </Project>

--- a/src/AasxPluginTechnicalData/AasxPluginTechnicalData.csproj
+++ b/src/AasxPluginTechnicalData/AasxPluginTechnicalData.csproj
@@ -25,8 +25,8 @@
     <ProjectReference Include="..\AasxPredefinedConcepts\AasxPredefinedConcepts.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.IO.Packaging" Version="7.0.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2025.2.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="System.IO.Packaging" Version="9.0.10" />
   </ItemGroup>
 </Project>

--- a/src/AasxPluginUaNetClient/AasxPluginUaNetClient.csproj
+++ b/src/AasxPluginUaNetClient/AasxPluginUaNetClient.csproj
@@ -22,7 +22,7 @@
     </Resource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.IO.Packaging" Version="7.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="System.IO.Packaging" Version="9.0.10" />
   </ItemGroup>
 </Project>

--- a/src/AasxPluginWebBrowser/AasxPluginWebBrowser.csproj
+++ b/src/AasxPluginWebBrowser/AasxPluginWebBrowser.csproj
@@ -11,7 +11,8 @@
 
     <!-- platform/target/runtime-->
     <TargetFramework>net8.0-windows</TargetFramework>
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <!-- <RuntimeIdentifier>win-x64</RuntimeIdentifier> -->
+	<RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">$(NETCoreSdkRuntimeIdentifier)</RuntimeIdentifier>
     <PlatformTarget>x64</PlatformTarget>
     <Platforms>x64</Platforms>
     <Platform>x64</Platform>
@@ -60,13 +61,13 @@
     <ProjectReference Include="..\AasxIntegrationBase\AasxIntegrationBase.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CefSharp.Common.NETCore" Version="137.0.100" />
-    <PackageReference Include="CefSharp.Wpf.NETCore" Version="137.0.100" />
-    <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.CodeDom" Version="7.0.0" />
+    <PackageReference Include="CefSharp.Common.NETCore" Version="141.0.110" />
+    <PackageReference Include="CefSharp.Wpf.NETCore" Version="141.0.110" />
+    <PackageReference Include="JetBrains.Annotations" Version="2025.2.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="System.CodeDom" Version="9.0.10" />
     <PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
-    <PackageReference Include="System.Formats.Asn1" Version="9.0.2" />
+    <PackageReference Include="System.Formats.Asn1" Version="9.0.10" />
     <PackageReference Include="System.Private.Uri" Version="4.3.2" />
   </ItemGroup>
   <ItemGroup>

--- a/src/AasxPluginWebBrowser/Plugin.cs
+++ b/src/AasxPluginWebBrowser/Plugin.cs
@@ -9,6 +9,7 @@ This source code may use other Open Source software components (see LICENSE.txt)
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -137,6 +138,15 @@ namespace AasxIntegrationBase // the namespace has to be: AasxIntegrationBase
                 this.browserGrid.ColumnDefinitions.Add(
                     new ColumnDefinition() { Width = new GridLength(1.0, GridUnitType.Star) });
 
+                // New: two instances of the AASPE crash because of Cef
+                var settings = new CefSharp.Wpf.CefSettings
+                {
+                    CachePath = $"C:\\Temp\\CEFCache_{Process.GetCurrentProcess().Id}"
+                };
+                if (Cef.IsInitialized != true)
+                    Cef.Initialize(settings);
+
+                // ok, start
                 this._browser = new CefSharp.Wpf.ChromiumWebBrowser();
                 this._browser.DownloadHandler = this;
                 // this._browser.RequestHandler = this;

--- a/src/AasxPredefinedConcepts/AasxPredefinedConcepts.csproj
+++ b/src/AasxPredefinedConcepts/AasxPredefinedConcepts.csproj
@@ -40,8 +40,8 @@
     <Content Include="README\Old_JSON_ConceptDescriptions.txt" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.IO.Packaging" Version="7.0.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2025.2.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="System.IO.Packaging" Version="9.0.10" />
   </ItemGroup>
 </Project>

--- a/src/AasxSchemaExport/AasxSchemaExport.csproj
+++ b/src/AasxSchemaExport/AasxSchemaExport.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.IO.Packaging" Version="7.0.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2025.2.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="System.IO.Packaging" Version="9.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AasxSignature/AasxSignature.csproj
+++ b/src/AasxSignature/AasxSignature.csproj
@@ -10,7 +10,7 @@
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.IO.Packaging" Version="7.0.0" />
+    <PackageReference Include="System.IO.Packaging" Version="9.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AasxToolkit/AasxToolkit.csproj
+++ b/src/AasxToolkit/AasxToolkit.csproj
@@ -106,11 +106,11 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ExhaustiveMatching.Analyzer" Version="0.5.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
-    <PackageReference Include="System.Formats.Asn1" Version="9.0.2" />
+    <PackageReference Include="System.Formats.Asn1" Version="9.0.10" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Private.Uri" Version="4.3.2" />
-    <PackageReference Include="System.Text.Json" Version="9.0.2" />
+    <PackageReference Include="System.Text.Json" Version="9.0.10" />
   </ItemGroup>
 </Project>

--- a/src/AasxWpfControlLibrary/AasxWpfControlLibrary.csproj
+++ b/src/AasxWpfControlLibrary/AasxWpfControlLibrary.csproj
@@ -45,18 +45,17 @@
     <Resource Include="Resources\IDTA_AAS-Logo_80x72_RGB.png" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2025.2.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
     <PackageReference Include="Microsoft.VisualBasic" Version="10.3.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="NPOI" Version="2.5.6" />
-    <PackageReference Include="QRCoder" Version="1.4.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="QRCoder" Version="1.7.0" />
     <PackageReference Include="RestSharp" Version="112.1.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
-    <PackageReference Include="System.Formats.Asn1" Version="9.0.2" />
-    <PackageReference Include="System.Text.Json" Version="9.0.2" />
-    <PackageReference Include="ZXing.Net" Version="0.16.8" />
-    <PackageReference Include="ZXing.Net.Bindings.Windows.Compatibility" Version="0.16.10" />
+    <PackageReference Include="System.Formats.Asn1" Version="9.0.10" />
+    <PackageReference Include="System.Text.Json" Version="9.0.10" />
+    <PackageReference Include="ZXing.Net" Version="0.16.11" />
+    <PackageReference Include="ZXing.Net.Bindings.Windows.Compatibility" Version="0.16.14" />
   </ItemGroup>
   <ItemGroup>
     <Page Remove="Dictionary1.xaml" />

--- a/src/AasxWpfControlLibrary/Flyouts/SelectFromDataGridFlyout.xaml.cs
+++ b/src/AasxWpfControlLibrary/Flyouts/SelectFromDataGridFlyout.xaml.cs
@@ -26,8 +26,6 @@ using System.Windows.Shapes;
 using AasxIntegrationBase;
 using AdminShellNS;
 using AnyUi;
-using Newtonsoft.Json;
-using NPOI.HPSF;
 
 namespace AasxPackageExplorer
 {

--- a/src/AnyUi/AnyUi.csproj
+++ b/src/AnyUi/AnyUi.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.IO.Packaging" Version="7.0.0" />
+    <PackageReference Include="System.IO.Packaging" Version="9.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BlazorExplorer/BlazorExplorer.csproj
+++ b/src/BlazorExplorer/BlazorExplorer.csproj
@@ -84,8 +84,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
     <PackageReference Include="RestSharp" Version="112.1.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
-    <PackageReference Include="System.Formats.Asn1" Version="9.0.2" />
-    <PackageReference Include="System.Text.Json" Version="9.0.2" />
+    <PackageReference Include="System.Formats.Asn1" Version="9.0.10" />
+    <PackageReference Include="System.Text.Json" Version="9.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MsaglWpfControl/MsaglWpfControl.csproj
+++ b/src/MsaglWpfControl/MsaglWpfControl.csproj
@@ -18,6 +18,6 @@
   <ItemGroup>
     <PackageReference Include="AutomaticGraphLayout" Version="1.1.12" />
     <PackageReference Include="AutomaticGraphLayout.Drawing" Version="1.1.12" />
-    <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2025.2.2" />
   </ItemGroup>
 </Project>

--- a/src/UIComponents.Flags.Blazor/UIComponents.Flags.Blazor.csproj
+++ b/src/UIComponents.Flags.Blazor/UIComponents.Flags.Blazor.csproj
@@ -12,8 +12,8 @@
 	</ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="6.0.33" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.33" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.21" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.21" />
   </ItemGroup>
 
 	<ItemGroup>

--- a/src/WpfMtpControl/WpfMtpControl.csproj
+++ b/src/WpfMtpControl/WpfMtpControl.csproj
@@ -17,10 +17,10 @@
     </Resource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Aml.Engine" Version="2.0.9" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Aml.Engine" Version="4.4.4" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
-    <PackageReference Include="System.Formats.Asn1" Version="9.0.2" />
-    <PackageReference Include="System.Text.Json" Version="9.0.2" />
+    <PackageReference Include="System.Formats.Asn1" Version="9.0.10" />
+    <PackageReference Include="System.Text.Json" Version="9.0.10" />
   </ItemGroup>
 </Project>

--- a/src/WpfMtpVisuViewer/WpfMtpVisuViewer.csproj
+++ b/src/WpfMtpVisuViewer/WpfMtpVisuViewer.csproj
@@ -21,9 +21,9 @@
     </Resource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
-    <PackageReference Include="System.Formats.Asn1" Version="9.0.2" />
-    <PackageReference Include="System.Text.Json" Version="9.0.2" />
+    <PackageReference Include="System.Formats.Asn1" Version="9.0.10" />
+    <PackageReference Include="System.Text.Json" Version="9.0.10" />
   </ItemGroup>
 </Project>

--- a/src/WpfXamlTool/WpfXamlTool.csproj
+++ b/src/WpfXamlTool/WpfXamlTool.csproj
@@ -13,7 +13,7 @@
     </Resource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AvalonEdit" Version="6.2.0.78" />
+    <PackageReference Include="AvalonEdit" Version="6.3.1.120" />
   </ItemGroup>
   <ItemGroup>
     <Page Remove="Resources\preset0.xaml" />


### PR DESCRIPTION
# Fix browser

When opening the AASP multiple times, the constructor of the CefSharp-Chromium-browser crashed and left the main window in a non-usable condition. With help of AI, crashing is prevented. However, the non-usable condition would still exist for another cause.

# Bump Nugets

Packages were upgraded as high as possible without strongly altering the code.

* FastMember / NPOI .. just deleted
* Grapevine .. MqttClient needs a work over, as logging would be fully changed
* MQTT.Net .. would also require work over of AasxMqttClient 
* Microsoft.AspNetCore.Components .. only bumped to 8.0.0, not 9.0.0 as still C#8
* ScottPlot .. upgrade to 5 will required work over of AasxPluginPlotting