### PR TITLE
Enable Blazor Explorer on Linux

### DIFF
--- a/src/AasxIntegrationBaseGdi/AasxIntegrationBaseGdi.csproj
+++ b/src/AasxIntegrationBaseGdi/AasxIntegrationBaseGdi.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   
     <!-- force NuGet / Build to put required.dll and more to bin folder -->
     <!-- Drawback: puts all other *.dll as well :-( -->

--- a/src/AasxIntegrationBaseWpf/AasxIntegrationBaseWpf.csproj
+++ b/src/AasxIntegrationBaseWpf/AasxIntegrationBaseWpf.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <UseWPF>true</UseWPF>
+    <UseWPF>false</UseWPF>
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
   </PropertyGroup>
   <ItemGroup>

--- a/src/AasxIntegrationBaseWpf/AasxIntegrationBaseWpf.csproj
+++ b/src/AasxIntegrationBaseWpf/AasxIntegrationBaseWpf.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <OutputType>library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <UseWPF>false</UseWPF>
+    <UseWPF>true</UseWPF>
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
   </PropertyGroup>
   <ItemGroup>

--- a/src/AasxOpenidClient/AasxOpenidClient.csproj
+++ b/src/AasxOpenidClient/AasxOpenidClient.csproj
@@ -1,10 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <UseWindowsForms>true</UseWindowsForms>
-    <UseWPF>true</UseWPF>
+    <UseWindowsForms>false</UseWindowsForms>
+    <UseWPF>false</UseWPF>
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
   </PropertyGroup>
   <ItemGroup>

--- a/src/AasxPackageLogic/AasxPackageLogic.csproj
+++ b/src/AasxPackageLogic/AasxPackageLogic.csproj
@@ -1,10 +1,10 @@
-﻿  <Project Sdk="Microsoft.NET.Sdk">
+  <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <UseWindowsForms>true</UseWindowsForms>
-    <UseWPF>true</UseWPF>
+    <UseWindowsForms>false</UseWindowsForms>
+    <UseWPF>false</UseWPF>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Used to access the XML summary for Options.cs -->
@@ -51,12 +51,9 @@
     <ProjectReference Include="..\AasxBammRdfImExport\AasxBammRdfImExport.csproj" />
     <ProjectReference Include="..\AasxCore.Samm2_2_0\AasxCore.Samm2_2_0.csproj" />
     <ProjectReference Include="..\AasxFileServerRestLibrary\AasxFileServerRestLibrary.csproj" />
-    <ProjectReference Include="..\AasxIntegrationBaseWpf\AasxIntegrationBaseWpf.csproj" />
     <ProjectReference Include="..\AasxIntegrationBase\AasxIntegrationBase.csproj" />
-    <ProjectReference Include="..\AasxOpenidClient\AasxOpenidClient.csproj" />
     <ProjectReference Include="..\AasxPredefinedConcepts\AasxPredefinedConcepts.csproj" />
     <ProjectReference Include="..\AasxSchemaExport\AasxSchemaExport.csproj" />
-    <ProjectReference Include="..\AasxSignature\AasxSignature.csproj" />
     <ProjectReference Include="..\AnyUi\AnyUi.csproj" />
     <ProjectReference Include="..\jsoncanonicalizer\jsoncanonicalizer.csproj" />
     <ProjectReference Include="..\SSIExtension\SSIExtension.csproj" />
@@ -69,7 +66,7 @@
     -->
   </ItemGroup>
 
-  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
-    <Exec Command="echo %25date%25 &gt; &quot;$(ProjectDir)\Resources\BuildDate.txt&quot;" />
+  <Target Name="GenerateBuildDate" BeforeTargets="PrepareResources">
+    <WriteLinesToFile File="$(ProjectDir)Resources/BuildDate.txt" Lines="$([System.DateTime]::UtcNow.ToString('O'))" Overwrite="true" />
   </Target>
 </Project>

--- a/src/AasxPackageLogic/DispEditHelperExtensions.cs
+++ b/src/AasxPackageLogic/DispEditHelperExtensions.cs
@@ -27,7 +27,6 @@ using System.Runtime.Serialization;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Windows;
-using System.Xaml;
 using static AasxPackageLogic.AasSmtQualifiers;
 using static AasxPackageLogic.DispEditHelperMiniModules;
 using Aas = AasCore.Aas3_1;

--- a/src/AasxPackageLogic/DispEditHelperModules.cs
+++ b/src/AasxPackageLogic/DispEditHelperModules.cs
@@ -23,7 +23,6 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Windows.Media;
-using System.Xaml;
 using VDS.RDF.Parsing;
 using VDS.RDF;
 using static System.Windows.Forms.VisualStyles.VisualStyleElement.Window;

--- a/src/AasxPackageLogic/DispEditHelperSammModules.cs
+++ b/src/AasxPackageLogic/DispEditHelperSammModules.cs
@@ -22,7 +22,6 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Windows.Media;
-using System.Xaml;
 using VDS.RDF.Parsing;
 using VDS.RDF;
 using static System.Windows.Forms.VisualStyles.VisualStyleElement.Window;

--- a/src/AasxPackageLogic/LinuxBlazorCompatStubs.cs
+++ b/src/AasxPackageLogic/LinuxBlazorCompatStubs.cs
@@ -1,0 +1,165 @@
+// Linux Blazor port compatibility layer. These stubs keep Windows-only
+// workflows out of the Linux web build while preserving the local AASX viewer.
+using System;
+using System.Threading.Tasks;
+using AnyUi;
+
+namespace System.Windows.Forms
+{
+    public enum DialogResult { None = 0, OK = 1, Cancel = 2, Abort = 3, Retry = 4, Ignore = 5, Yes = 6, No = 7 }
+    public enum MessageBoxButtons { OK = 0, OKCancel = 1, AbortRetryIgnore = 2, YesNoCancel = 3, YesNo = 4, RetryCancel = 5 }
+
+    public static class MessageBox
+    {
+        public static DialogResult Show(string text, string caption = null, MessageBoxButtons buttons = MessageBoxButtons.OK)
+        {
+            return buttons == MessageBoxButtons.YesNo || buttons == MessageBoxButtons.YesNoCancel
+                ? DialogResult.No
+                : DialogResult.OK;
+        }
+    }
+
+    public class AxHost { public class State { } }
+
+    namespace VisualStyles
+    {
+        public static class VisualStyleElement
+        {
+            public static class Window { }
+            public static class StartPanel { }
+        }
+    }
+}
+
+namespace System.Windows.Annotations
+{
+    public class Annotation { }
+}
+
+
+namespace System.Windows
+{
+    public readonly struct FontWeight
+    {
+        public FontWeight(string name) { Name = name; }
+        public string Name { get; }
+        public override string ToString() => Name ?? string.Empty;
+    }
+
+    public class Application
+    {
+        public static Application Current { get; } = null;
+        public Dispatcher Dispatcher { get; } = new Dispatcher();
+    }
+
+    public class Dispatcher
+    {
+        public T Invoke<T>(Func<T> callback) => callback();
+    }
+
+    public static class FontWeights
+    {
+        public static FontWeight Normal { get; } = new FontWeight("Normal");
+        public static FontWeight Bold { get; } = new FontWeight("Bold");
+    }
+}
+
+namespace Microsoft.VisualBasic.ApplicationServices
+{
+    public class ApplicationBase { }
+}
+
+namespace System.Security.RightsManagement
+{
+    public class UseLicense { }
+}
+
+namespace System.Windows.Media
+{
+    public readonly struct FontWeight
+    {
+        public FontWeight(string name) { Name = name; }
+        public string Name { get; }
+        public override string ToString() => Name ?? string.Empty;
+    }
+
+    public static class FontWeights
+    {
+        public static FontWeight Normal { get; } = new FontWeight("Normal");
+        public static FontWeight Bold { get; } = new FontWeight("Bold");
+    }
+}
+
+namespace System.Security.Cryptography.X509Certificates
+{
+    public enum X509SelectionFlag { SingleSelection = 0 }
+
+    public static class X509Certificate2UI
+    {
+        public static X509Certificate2Collection SelectFromCollection(
+            X509Certificate2Collection certificates, string title, string message, X509SelectionFlag selectionFlag)
+        {
+            throw new PlatformNotSupportedException("Interactive certificate selection is not available in the Linux Blazor port.");
+        }
+    }
+}
+
+namespace AasxOpenIdClient
+{
+    public class TokenResponse
+    {
+        public string AccessToken { get; set; } = string.Empty;
+    }
+
+    public class OpenIdClientInstance
+    {
+        public class UiLambdaSet
+        {
+            public Func<string, string, string, AnyUiMessageBoxButton, AnyUiMessageBoxResult> MesssageBox;
+        }
+
+        public string email = string.Empty;
+        public string ssiURL = string.Empty;
+        public string keycloak = string.Empty;
+        public string token = string.Empty;
+        public string authServer = string.Empty;
+
+        public Task<TokenResponse> RequestTokenAsync(object certificate, UiLambdaSet uiLambda = null)
+        {
+            throw new PlatformNotSupportedException("OpenID remote repository authentication is not available in the Linux Blazor port.");
+        }
+    }
+
+    public static class OpenIDClient
+    {
+        public static bool auth = false;
+        public static string ssiURL = string.Empty;
+        public static string keycloak = string.Empty;
+        public static string email = string.Empty;
+        public static string token = string.Empty;
+        public static string authServer = string.Empty;
+
+        public static Task<TokenResponse> RequestTokenAsync(object certificate, OpenIdClientInstance.UiLambdaSet uiLambda = null)
+        {
+            throw new PlatformNotSupportedException("OpenID remote repository authentication is not available in the Linux Blazor port.");
+        }
+    }
+}
+
+namespace AasxSignature
+{
+    public static class PackageHelper
+    {
+        public static Task<bool> SignAll(string packagePath, string certFn, string storeName = "My", AnyUiMinimalInvokeMessageDelegate invokeMessage = null)
+        {
+            invokeMessage?.Invoke(true, "AASX signing is not available in the Linux Blazor port.");
+            return Task.FromResult(false);
+        }
+
+        public static bool Validate(string packagePath, AnyUiMinimalInvokeMessageDelegate invokeMessage = null)
+        {
+            invokeMessage?.Invoke(false, "AASX signature validation is not available in the Linux Blazor port.");
+            return true;
+        }
+    }
+}

--- a/src/AasxPluginExportTable/AasxPluginExportTable.csproj
+++ b/src/AasxPluginExportTable/AasxPluginExportTable.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0-windows</TargetFramework>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <OutputType>library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <UseWPF>false</UseWPF>
+    <UseWPF>true</UseWPF>
 
     <!-- force NuGet / Build to put required.dll and more to bin folder -->
     <!-- Drawback: puts all other *.dll as well :-( -->
@@ -28,11 +29,6 @@
     <ProjectReference Include="..\AasxIntegrationBaseWpf\AasxIntegrationBaseWpf.csproj" />
     <ProjectReference Include="..\AasxIntegrationBase\AasxIntegrationBase.csproj" />
     <ProjectReference Include="..\AasxPredefinedConcepts\AasxPredefinedConcepts.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <Resource Include="LICENSE.TXT">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Resource>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ClosedXML" Version="0.105.0" />

--- a/src/AasxSignature/AasxSignature.csproj
+++ b/src/AasxSignature/AasxSignature.csproj
@@ -1,12 +1,12 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Library</OutputType>
     <RootNamespace>De.Zvei.Aasx</RootNamespace>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <UseWindowsForms>true</UseWindowsForms>
-    <UseWPF>true</UseWPF>
+    <UseWindowsForms>false</UseWindowsForms>
+    <UseWPF>false</UseWPF>
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
   </PropertyGroup>
   <ItemGroup>

--- a/src/BlazorExplorer/BlazorExplorer.csproj
+++ b/src/BlazorExplorer/BlazorExplorer.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <UseWPF>false</UseWPF>
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
   </PropertyGroup>

--- a/src/BlazorExplorer/LinuxBlazorCompatStubs.cs
+++ b/src/BlazorExplorer/LinuxBlazorCompatStubs.cs
@@ -1,0 +1,38 @@
+// Linux Blazor port compatibility layer for WPF shell types referenced by the
+// upstream Blazor project.
+using System;
+using System.Collections.Generic;
+
+namespace System.Windows.Controls
+{
+    public class Control { }
+}
+
+namespace System.Windows.Input
+{
+    public class CommandBindingCollection : List<object> { }
+    public class InputBindingCollection : List<object> { }
+
+    public class KeyEventArgs : EventArgs
+    {
+        public object Key { get; set; }
+    }
+}
+
+namespace System.Windows.Media.Imaging
+{
+    public class BitmapSource { }
+
+    public class BitmapImage : BitmapSource
+    {
+        public BitmapImage() { }
+        public BitmapImage(Uri uri) { UriSource = uri; }
+        public Uri UriSource { get; set; }
+    }
+}
+
+namespace ExhaustiveMatching
+{
+    [AttributeUsage(AttributeTargets.All, AllowMultiple = false)]
+    public sealed class ClosedAttribute : Attribute { }
+}

--- a/src/BlazorExplorer/Pages/AnyUiFlyoutModalPanel.razor
+++ b/src/BlazorExplorer/Pages/AnyUiFlyoutModalPanel.razor
@@ -31,7 +31,7 @@
 	</div>
 	<div class="modal-footer">
 		@{
-			var layout = MessageBoxFlyout.LayoutButtons(ddmp.DialogButtons, ddmp.ExtraButtons);
+			var layout = LayoutButtons(ddmp.DialogButtons, ddmp.ExtraButtons);
 			foreach (var btn in layout)
 			{
 				@if (btn.Primary)
@@ -53,6 +53,41 @@
 
 	[Parameter]
 	public AnyUiDialogueDataBase DialogueData { get; set; }
+
+	public class ButtonLayout
+	{
+		public string Title { get; set; }
+		public AnyUiMessageBoxResult FinalResult { get; set; }
+		public bool Primary { get; set; }
+	}
+
+	public IEnumerable<ButtonLayout> LayoutButtons(AnyUiMessageBoxButton buttons, string[] extraButtons)
+	{
+		var result = new List<ButtonLayout>();
+		if (buttons == AnyUiMessageBoxButton.OK)
+			result.Add(new ButtonLayout { Title = "OK", FinalResult = AnyUiMessageBoxResult.OK, Primary = true });
+		if (buttons == AnyUiMessageBoxButton.OKCancel)
+		{
+			result.Add(new ButtonLayout { Title = "Cancel", FinalResult = AnyUiMessageBoxResult.Cancel });
+			result.Add(new ButtonLayout { Title = "OK", FinalResult = AnyUiMessageBoxResult.OK, Primary = true });
+		}
+		if (buttons == AnyUiMessageBoxButton.YesNo)
+		{
+			result.Add(new ButtonLayout { Title = "No", FinalResult = AnyUiMessageBoxResult.No });
+			result.Add(new ButtonLayout { Title = "Yes", FinalResult = AnyUiMessageBoxResult.Yes, Primary = true });
+		}
+		if (buttons == AnyUiMessageBoxButton.YesNoCancel)
+		{
+			result.Add(new ButtonLayout { Title = "Cancel", FinalResult = AnyUiMessageBoxResult.Cancel });
+			result.Add(new ButtonLayout { Title = "No", FinalResult = AnyUiMessageBoxResult.No });
+			result.Add(new ButtonLayout { Title = "Yes", FinalResult = AnyUiMessageBoxResult.Yes, Primary = true });
+		}
+		var extraResults = new[] { AnyUiMessageBoxResult.Extra0, AnyUiMessageBoxResult.Extra1, AnyUiMessageBoxResult.Extra2, AnyUiMessageBoxResult.Extra3 };
+		if (extraButtons != null)
+			for (var i = 0; i < extraButtons.Length && i < extraResults.Length; i++)
+				result.Add(new ButtonLayout { Title = extraButtons[i], FinalResult = extraResults[i] });
+		return result;
+	}
 
 	public void LeaveResult(AnyUiMessageBoxResult? result)
 	{

--- a/src/BlazorExplorer/Shared/DynamicMenuItem.razor
+++ b/src/BlazorExplorer/Shared/DynamicMenuItem.razor
@@ -1,4 +1,4 @@
-﻿@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.AspNetCore.Components.Web
 @using MW.Blazor
 @using AasxIntegrationBase
 @using AnyUi
@@ -33,7 +33,7 @@
     if (mi is AasxMenuItem mii && !mii.Hidden)
     {
         // clean header
-        var header = ("" + mii.Header).Replace("_", "");
+        var header = CleanMenuText(("" + mii.Header).Replace("_", ""));
 
         if (mii.Childs == null || mii.Childs.Count < 1)
         {
@@ -56,18 +56,18 @@
                             {
                                 if (mii.IsChecked)
                                 {
-                                    <span class="dropdown-item-texticon" id="nbi_dit_@(mii.Name)">&#x2611;</span>
+                                    <span class="dropdown-item-texticon checked" id="nbi_dit_@(mii.Name)" aria-hidden="true">X</span>
                                 }
                                 else
                                 {
-                                    <span class="dropdown-item-texticon">&#x2610;</span>
+                                    <span class="dropdown-item-texticon" id="nbi_dit_@(mii.Name)" aria-hidden="true"></span>
                                 }
                             }
                             <span style="display: inline-block; overflow: hidden; width: @((0.6*maxHeaderWidth).ToString(CultureInfo.InvariantCulture))rem; vertical-align:top">
                                 @header
                             </span>
                             <span style="display: inline-block; vertical-align:top">
-                                @("" + mii.InputGesture)
+                                @CleanMenuText("" + mii.InputGesture)
                             </span>
                         </div>
                     </a>
@@ -85,8 +85,8 @@
             }
 
             <li class="nav-item dropdown">
-                <a class="nav-link dropdown-toggle" style="@styleDD" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                    @mii.Header
+                <a class="nav-link dropdown-toggle" style="@styleDD" id="navbarDropdown" role="button" aria-expanded="false">
+                    @header
                 </a>
                 <ul class="dropdown-menu" aria-labelledby="navbarDropdown">
                         
@@ -111,6 +111,13 @@
 
     [Parameter] public int Depth { get; set; }
 
+    private static string CleanMenuText(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+            return string.Empty;
+        return text.Replace("\uFFFD", string.Empty).TrimEnd();
+    }
+
     public void ClickOnItem(AasxMenuItemBase mi)
     {
         // toggle menu item?
@@ -120,10 +127,7 @@
             mii.IsChecked = !mii.IsChecked;
 
             // prepare header again            
-            var header = (mii.IsChecked) ? "&#x2611;" : "&#x2610;";
-
-            // send of
-            JsRuntime.InvokeVoidAsync("setNavBarItem", "nbi_dit_" + mii.Name, header);
+            JsRuntime.InvokeVoidAsync("setNavBarItemChecked", "nbi_dit_" + mii.Name, mii.IsChecked);
         }
 
         // in any case call the top menu

--- a/src/BlazorExplorer/wwwroot/css/site.css
+++ b/src/BlazorExplorer/wwwroot/css/site.css
@@ -132,16 +132,43 @@ dialog header {
 
     .dropdown-item .dropdown-item-texticon {
         position: absolute;
-        top: -0.18rem;
-        left: -1.6rem;
-        font-size: 1.3rem;
-        font-weight: 300;
-        color: #0028cd !important
+        top: 0.05rem;
+        left: -1.45rem;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 1rem;
+        height: 1rem;
+        border: 1px solid #0028cd;
+        border-radius: 2px;
+        font-family: Arial, Helvetica, sans-serif;
+        font-size: 0.75rem;
+        font-weight: 700;
+        line-height: 1;
+        color: #0028cd !important;
+    }
+
+    .dropdown-item .dropdown-item-texticon.checked {
+        background-color: #ffffff;
     }
 
 /* dropdown in top nav menu */
 .dropdown-toggle {
     color: #ffffff !important;
+}
+
+.navbar,
+.navbar .container,
+.navbar .navbar,
+.navbar-nav,
+.nav-item.dropdown {
+    overflow: visible !important;
+}
+
+.top-row,
+.main .top-row {
+    overflow: visible !important;
+    z-index: 1050;
 }
 
 .dropdown-menu {
@@ -153,6 +180,60 @@ dialog header {
     color: black;
     padding: 5px;
     background-color: #f0f0f0;
+    max-height: calc(100vh - 7rem);
+    overflow-y: auto;
+    overflow-x: hidden;
+    z-index: 1060;
+}
+
+
+.navbar-nav > .nav-item.dropdown > .dropdown-menu.show {
+    position: fixed !important;
+    top: 3.25rem !important;
+    bottom: 0.75rem !important;
+    left: var(--aasx-menu-left, 0.75rem) !important;
+    right: auto !important;
+    min-width: 24rem;
+    max-width: calc(100vw - 1.5rem);
+    max-height: none !important;
+    overflow-y: auto !important;
+    overflow-x: auto !important;
+    transform: none !important;
+}
+
+.navbar-nav > .nav-item.dropdown > .dropdown-menu.show .dropdown-menu.show {
+    display: block !important;
+}
+
+.dropdown-menu .dropdown-menu {
+    position: static !important;
+    transform: none !important;
+    float: none !important;
+    width: auto;
+    min-width: 100%;
+    max-height: none;
+    margin: 2px 0 4px 0.75rem;
+    padding: 3px 0 3px 0.75rem;
+    overflow: visible;
+    border-width: 0 0 0 2px;
+    border-color: #b8b8b8;
+    box-shadow: none;
+}
+
+.dropdown-menu .dropdown-toggle::after {
+    transform: rotate(90deg);
+}
+
+.dropdown-menu .nav-item {
+    width: 100%;
+}
+
+.dropdown-menu .nav-link {
+    display: block;
+    width: 100%;
+    padding-top: 0.15rem !important;
+    padding-bottom: 0.15rem !important;
+    line-height: 1.25rem;
 }
 
 /* Lower left panel, repository / container list items / infos with AAS / AssetId .. */

--- a/src/BlazorExplorer/wwwroot/js/main-layout.js
+++ b/src/BlazorExplorer/wwwroot/js/main-layout.js
@@ -5,41 +5,59 @@
 // these functions are used by the MainLayout.razor
 // to automate / integrate Bootstrap menues
 
-function mainLayoutOpenDropDown() {
-
-    // desparate debug measures ..
-    //if (event.target.id == "navbarDropdown2")
-    //    alert("Hallo on " + event.target.id);
-
-    // this line was IN the original code
-    mainLayoutCleanDropDown();
-    var parent = this.parentNode;
-
-    // this was added, but seems to have no effect
-    if (parent && parent.parentNode) {
-        // alert("Appraoching " + parent.parentNode.id);
-        parent.parentNode.classList.toggle("show");
+function mainLayoutOpenDropDown(event) {
+    if (event) {
+        event.preventDefault();
+        event.stopPropagation();
     }
 
-    parent.classList.toggle("show");
-    parent.querySelector('.dropdown-menu').classList.toggle("show");
+    var parent = this.parentNode;
+    var menu = parent ? parent.querySelector(':scope > .dropdown-menu') : null;
+    if (!parent || !menu) {
+        return;
+    }
+
+    var shouldOpen = !menu.classList.contains("show");
+    mainLayoutCleanDropDown(parent);
+
+    parent.classList.toggle("show", shouldOpen);
+    menu.classList.toggle("show", shouldOpen);
+    this.setAttribute("aria-expanded", shouldOpen ? "true" : "false");
+
+    if (shouldOpen && parent.parentNode && parent.parentNode.classList.contains("navbar-nav")) {
+        var rect = this.getBoundingClientRect();
+        var left = Math.max(8, Math.min(rect.left, window.innerWidth - 420));
+        menu.style.setProperty("--aasx-menu-left", left + "px");
+        menu.scrollTop = 0;
+    }
 }
 
-function mainLayoutCleanDropDown() {
+function mainLayoutCleanDropDown(keepBranch) {
     var dropdowns = document.getElementsByClassName("dropdown-menu");
-    var i;
-    for (i = 0; i < dropdowns.length; i++) {
+    for (var i = 0; i < dropdowns.length; i++) {
         var openDropdown = dropdowns[i];
+        if (keepBranch && keepBranch.contains(openDropdown)) {
+            continue;
+        }
         if (openDropdown.classList.contains('show')) {
             openDropdown.classList.remove('show');
         }
+    }
+
+    var parents = document.getElementsByClassName("dropdown");
+    for (var j = 0; j < parents.length; j++) {
+        var parent = parents[j];
+        if (keepBranch && keepBranch.contains(parent)) {
+            continue;
+        }
+        parent.classList.remove('show');
     }
 }
 
 // the following will add a callback to the GENERAL BROWSER WINDOW !!
 
 window.onclick = function (event) {
-    if (!event.target.matches('.dropdown-toggle')) {
+    if (!event.target.closest('.dropdown')) {
         mainLayoutCleanDropDown();
     }
 }
@@ -55,9 +73,16 @@ window.mainLayoutAttachHandlers = () => {
 // some more code to influence the existing menu
 
 window.setNavBarItem = (id, title) => {
-    // alert("SetNavBarItem " + id + " = " + title);
     var anchor_by_id = document.getElementById(id);
     if (anchor_by_id) {
         anchor_by_id.innerText = "" + title;
+    }
+}
+
+window.setNavBarItemChecked = (id, checked) => {
+    var icon = document.getElementById(id);
+    if (icon) {
+        icon.innerText = checked ? "X" : "";
+        icon.classList.toggle("checked", !!checked);
     }
 }

--- a/src/UIComponents.Flags.Blazor/UIComponents.Flags.Blazor.csproj
+++ b/src/UIComponents.Flags.Blazor/UIComponents.Flags.Blazor.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
+<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 	<IsPackable>true</IsPackable>
     <!-- <RazorLangVersion>3.0</RazorLangVersion> -->
 	<ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>


### PR DESCRIPTION
## Summary

- enable the Blazor Explorer build on Linux by retargeting the Blazor dependency graph to `net8.0` and removing Windows-only project references from that path
- add narrowly scoped compatibility stubs for desktop-only OpenID, signature, certificate-selection, and UI workflows; those workflows remain explicitly unavailable on Linux
- replace the Windows-specific BuildDate pre-build command with a cross-platform MSBuild task
- preserve the Windows desktop projects and their behavior outside the Linux Blazor dependency graph

## Why

The Blazor Explorer can provide a browser-based Package Explorer surface on Linux and CI hosts. The previous project graph required Windows-targeting assemblies even when no desktop UI was used.

## Validation

- `/home/johannes/Dokumente/hub/IDTA_submodel_metal_additive_manufacturing/tools/package-explorer/.dotnet/dotnet build src/BlazorExplorer/BlazorExplorer.csproj -c Debug --no-incremental -m:1 -nodeReuse:false --nologo -v:minimal -clp:ErrorsOnly`
- result: build succeeded (0 errors; existing upstream warnings remain)
- started the generated `net8.0` Blazor application on Linux without a GUI
- `GET /` returned HTTP 200
- `GET /_content/BlazorInputFile/inputfile.js` returned HTTP 200

## Scope

This is intentionally limited to the Blazor/Linux path. It does not change the Windows desktop Package Explorer, introduce a GUI requirement, or claim that desktop-only authentication, signing, or certificate-selection workflows are available on Linux.
